### PR TITLE
Fix match selection for `goToFirstMatch`

### DIFF
--- a/src/findJump.ts
+++ b/src/findJump.ts
@@ -3,6 +3,7 @@ import { AssociationManager } from './associationManager';
 import { extensionConfig, Global } from './extension';
 import { getMatchesAndAvailableJumpChars } from './getMatches';
 import { InlineInput } from './inlineInput';
+import { first } from './utils';
 
 export class FindJump {
 	isActive = false;
@@ -163,9 +164,9 @@ export class FindJump {
 	};
 
 	goToFirstMatch = (): void => {
-		const inputs = Array.from(this.associationManager.associations.entries()).sort((a, b) => b[1].start.line - a[1].start.line);
-		if (inputs.length > 0) {
-			this.jump(inputs[inputs.length - 1][0]);
+		const target = first([...this.associationManager.associations.entries()], ([, { start: a }], [, { start: b }]) => a.compareTo(b));
+		if (target) {
+			this.jump(target[0]);
 		}
 	};
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -18,3 +18,7 @@ export function getIntRange(start: number, end: number): number[] {
 	}
 	return range;
 }
+
+export function first<T>(items: T[], compare: (a: T, b: T)=> number): T | undefined {
+	return items.slice(1).reduce((min, item) => compare(item, min) > 0 ? min : item, items[0]);
+}


### PR DESCRIPTION
Now properly select the first match in a line that has multiple matches.

Also switch to using a less algorithmically complex method to find the "first" range, without having to sort out all of these ranges.

Fixes #25.