### PR TITLE
Better jump chars exclusion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
 		"": {
 			"name": "find-jump",
 			"version": "0.6.2",
+			"license": "MIT",
 			"devDependencies": {
 				"@soda/friendly-errors-webpack-plugin": "^1.8.0",
 				"@types/node": "^14.17.21",

--- a/src/getMatches.ts
+++ b/src/getMatches.ts
@@ -75,10 +75,6 @@ export function getMatchesAndAvailableJumpChars(editor: TextEditor, needle: stri
 		// @ts-ignore
 		const lineMatches = getLineMatches(line, needle);
 		for (const lineMatch of lineMatches) {
-			if (matches.length >= availableJumpChars.length) {
-				break outer;
-			}
-
 			matches.push({ value: lineMatch, index });
 
 			for (const excludedChar of lineMatch.excludedChars) {


### PR DESCRIPTION
Fixes https://github.com/usernamehw/vscode-find-jump/issues/30

The change is that we do not stop after finding enough matches, so we gather all "banned" jump chars.
It is ok, when `findJump.onlyVisibleRanges` is `true`, but may be slow when it is `false`.

Do you think we should enable this fix only when `findJump.onlyVisibleRanges == true`?