### PR TITLE
Option: Jump location based on if selection is activated

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,12 +79,14 @@
 					"default": "start",
 					"enum": [
 						"start",
-						"end"
+						"end",
+						"selection-end"
 					],
 					"description": "Place where to jump cursor.",
 					"enumDescriptions": [
 						"Jump to the start of the range.",
-						"Jump to the end of the range."
+						"Jump to the end of the range.",
+						"Start of the range on jump, end of the range on selection."
 					]
 				},
 				"findJump.letterBackground": {

--- a/package.json
+++ b/package.json
@@ -80,7 +80,8 @@
 					"enum": [
 						"start",
 						"end",
-						"selection-end"
+						"selection-end",
+						"selection+1"
 					],
 					"description": "Place where to jump cursor.",
 					"enumDescriptions": [

--- a/src/findJump.ts
+++ b/src/findJump.ts
@@ -109,7 +109,9 @@ export class FindJump {
 			return;
 		}
 
-		const cursorPosition = extensionConfig.jumpCursorPosition;
+		const cursorPosition = extensionConfig.jumpCursorPosition !== 'selection-end'
+			? extensionConfig.jumpCursorPosition
+			: this.activatedWithSelection ? 'end' : 'start';
 		const { line, character } = range[cursorPosition];
 
 		this.textEditor.selection = new Selection(

--- a/src/findJump.ts
+++ b/src/findJump.ts
@@ -119,7 +119,7 @@ export class FindJump {
 		if (extensionConfig.jumpCursorPosition === 'selection+1') {
 			const r = range['start'];
 			line = r.line;
-			character = r.character + 1;
+			character = r.character + (selectionForward ? 1 : 0);
 		} else {
 			const cursorPosition = extensionConfig.jumpCursorPosition !== 'selection-end'
 				? extensionConfig.jumpCursorPosition

--- a/src/findJump.ts
+++ b/src/findJump.ts
@@ -109,10 +109,25 @@ export class FindJump {
 			return;
 		}
 
-		const cursorPosition = extensionConfig.jumpCursorPosition !== 'selection-end'
-			? extensionConfig.jumpCursorPosition
-			: this.activatedWithSelection ? 'end' : 'start';
-		const { line, character } = range[cursorPosition];
+		const befLine = this.textEditor.selection.start.line;
+		const befChar = this.textEditor.selection.start.character;
+		const aftLine = range['start'].line;
+		const aftChar = range['start'].character;
+		const selectionForward = (aftLine*1000+aftChar) >= (befLine*1000+befChar)
+
+		let line, character;
+		if (extensionConfig.jumpCursorPosition === 'selection+1') {
+			const r = range['start'];
+			line = r.line;
+			character = r.character + 1;
+		} else {
+			const cursorPosition = extensionConfig.jumpCursorPosition !== 'selection-end'
+				? extensionConfig.jumpCursorPosition
+				: (this.activatedWithSelection && selectionForward) ? 'end' : 'start';
+			const r = range[cursorPosition];
+			line = r.line;
+			character = r.character;
+		}
 
 		this.textEditor.selection = new Selection(
 			this.activatedWithSelection ? this.textEditor.selection.start.line : line,

--- a/src/findJump.ts
+++ b/src/findJump.ts
@@ -119,7 +119,7 @@ export class FindJump {
 		if (extensionConfig.jumpCursorPosition === 'selection+1') {
 			const r = range['start'];
 			line = r.line;
-			character = r.character + (selectionForward ? 1 : 0);
+			character = r.character + (this.activatedWithSelection && selectionForward ? 1 : 0);
 		} else {
 			const cursorPosition = extensionConfig.jumpCursorPosition !== 'selection-end'
 				? extensionConfig.jumpCursorPosition

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,7 +5,7 @@ export interface ExtensionConfig {
 	positionAbsolute: boolean;
 	dimWhenActive: boolean;
 	activateToToggle: boolean;
-	jumpCursorPosition: 'end' | 'start';
+	jumpCursorPosition: 'end' | 'start' | 'selection-end';
 
 	letterBackground: string;
 	letterForeground: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,7 +5,7 @@ export interface ExtensionConfig {
 	positionAbsolute: boolean;
 	dimWhenActive: boolean;
 	activateToToggle: boolean;
-	jumpCursorPosition: 'end' | 'start' | 'selection-end';
+	jumpCursorPosition: 'end' | 'start' | 'selection-end' | 'selection+1';
 
 	letterBackground: string;
 	letterForeground: string;


### PR DESCRIPTION
One thing I was missinf from the original extension, and the fork as well, was the option to go to the start of the range when doing a jump, and go to the end of the range when doing a selection, because that was how I internally thought about the selection "I want to select the word selection from `<s>` to `<n>`", so I added it.